### PR TITLE
CI時に作ったhtml/assetsを使うようにした

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ cache:
     - node_modules
     - bower_components
 deploy:
+  skip_cleanup: true
   provider: script
   script: ./deploy.sh
   on:

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,9 +19,6 @@ chmod 600 "$SSH_FILE" \
 git config --global user.email "rintyo_@hotmail.com"
 git config --global user.name "Travis CI"
 
-# build
-npm run build
-
 # deploy
 mkdir tmp
 mv *.html assets tmp

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # See https://medium.com/@nthgergo/publishing-gh-pages-with-travis-ci-53a8270e87db
+set -o xtrace
 set -o errexit
 
 declare -r SSH_FILE="$(mktemp -u $HOME/.ssh/XXXXX)"


### PR DESCRIPTION
> Cleaning up git repository with `git stash --all`. If you need build artifacts for deployment, set
> `deploy.skip_cleanup: true`. See https://docs.travis-ci.com/user/deployment/#Uploading-Files.
ってtravisのメッセージに書いてあったので。