### PR TITLE
Fix the link for the external article.

### DIFF
--- a/src/slim/conference.slim
+++ b/src/slim/conference.slim
@@ -69,7 +69,8 @@
       .timeline_label.row
         .col-sm
           h4 Apache BigtopによるDockerコンテナ上へのHadoopソフトウェアスタックの導入
-          p Hadoop やその周辺プロダクトを試してみたい人や、手っ取り早く動作確認するための環境が欲しい人向けに、Apache Bigtop を使って Docker コンテナ上に Hadoop ソフトウェアスタックを簡単に構築する方法を紹介します。以下の記事 (推敲中) ±α の内容を話します。http://qiita.com/sekikn/private/18954e9b302c38eb5b55
+          p Hadoop やその周辺プロダクトを試してみたい人や、手っ取り早く動作確認するための環境が欲しい人向けに、Apache Bigtop を使って Docker コンテナ上に Hadoop ソフトウェアスタックを簡単に構築する方法を紹介します。以下の記事±αの内容を話します。
+          a.presenter href="http://qiita.com/sekikn/items/18954e9b302c38eb5b55" http://qiita.com/sekikn/items/18954e9b302c38eb5b55
           br
           | 関堅吾(
           a.presenter href="https://twitter.com/sekikn39" @sekikn39


### PR DESCRIPTION
In the abstract, http://qiita.com/sekikn/private/18954e9b302c38eb5b55 has become public and the URL has changed to http://qiita.com/sekikn/items/18954e9b302c38eb5b55.
This commit renames the URL and add a link to the URL. 