### PR TITLE
gemのinstallに --no-ri --no-rdoc 追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 before_script:
-  - gem install slim aws-sdk
+  - gem install slim aws-sdk --no-ri --no-rdoc
   - npm install
 language: javascript
 env:


### PR DESCRIPTION
ドキュメントのセットアップをスキップすることでgemのinstallに掛かる時間が微妙に短くなる。