### PR TITLE
Add content type for preview site.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 dist: trusty
 sudo: false
 before_script:
-  - gem install slim aws-sdk github_api --no-ri --no-rdoc
+  - gem install slim aws-sdk github_api mime-types --no-ri --no-rdoc
   - npm install
 language: javascript
 rvm:

--- a/.travis/upload.rb
+++ b/.travis/upload.rb
@@ -1,6 +1,7 @@
 require 'aws-sdk'
 require 'json'
 require 'github_api'
+require 'mime/types'
 
 BUCKET = 'ntt-tech-conference-01'
 REGION = 'ap-northeast-1'
@@ -20,7 +21,8 @@ class AWSclient
       @s3.put_object(acl: 'public-read',
                      storage_class: "REDUCED_REDUNDANCY",
                      bucket: BUCKET,
-                     key: s3key, body: f)
+                     key: s3key, body: f,
+                     content_type: MIME::Types.type_for(file)[0].to_s)
     }
   end
 end


### PR DESCRIPTION
Preview site cannot be seen from IE11. This is because content-type is missing in S3 preview site.